### PR TITLE
Fix incorrect memory layout on Rust >= 1.67.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ cef_cache/
 hs_err_pid*.log
 
 # Do not commit CEF binaries
-/java-cef/org.eclipse.set.browser.cef/cef
+/java/org.eclipse.set.browser.cef.win32/cef
 /cef

--- a/native/chromium/build.rs
+++ b/native/chromium/build.rs
@@ -110,6 +110,7 @@ fn gen_cef(cef_path: std::path::Display) {
     dst.write(new_data.as_bytes()).expect("Cannot write mod.rs");
 }
 
+#[repr(C)]
 #[derive(Debug)]
 struct ToJavaCallbacks();
 

--- a/native/chromium_subp/src/app/mod.rs
+++ b/native/chromium_subp/src/app/mod.rs
@@ -17,6 +17,7 @@ use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::c_int;
 
+#[repr(C)]
 pub struct Base {}
 
 impl Base {
@@ -31,6 +32,7 @@ impl Base {
     }
 }
 
+#[repr(C)]
 pub struct App {
     cef: chromium::cef::_cef_app_t,
     render_process_handler: RenderProcessHandler,
@@ -76,10 +78,12 @@ impl App {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy)]
 struct Browser(*mut chromium::cef::_cef_browser_t);
 unsafe impl Send for Browser {}
 
+#[repr(C)]
 struct RenderProcessHandler {
     cef: chromium::cef::_cef_render_process_handler_t,
     function_handler: Option<V8Handler>,
@@ -307,6 +311,7 @@ unsafe fn convert_type(
     }
 }
 
+#[repr(C)]
 struct V8Handler {
     cef: chromium::cef::_cef_v8handler_t,
     browser: *mut chromium::cef::_cef_browser_t,

--- a/native/chromium_subp/src/socket.rs
+++ b/native/chromium_subp/src/socket.rs
@@ -40,12 +40,14 @@ impl ReturnType {
     }
 }
 
+#[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReturnSt {
     pub kind: ReturnType,
     pub str_value: CString,
 }
 
+#[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
 struct ReturnMsg {
     kind: ReturnType,


### PR DESCRIPTION
Since Rust 1.67.0, the Rust compiler groups fields in a struct if it improves alignment. See https://github.com/rust-lang/rust/pull/102750 for details. Prior to that change, in some cases `repr(Rust)` and `repr(C)` structs had the same memory layout, which now differs, breaking C<=>Rust interfacing. 

We've had a few instances in the code where we (implicitly) relied on the memory layout being equivalent to `repr(C)`, which stopped some of the browser functions from working if compiled with a newer Rust version.