### PR TITLE
Set DPI awareness for chromium_subp to "System Aware"

### DIFF
--- a/native/chromium_subp/src/bin/chromium_subp.rs
+++ b/native/chromium_subp/src/bin/chromium_subp.rs
@@ -20,6 +20,18 @@ use std::os::raw::c_int;
 use std::ptr::null_mut;
 
 fn main() {
+    // Disable High DPI per Monitor support.
+    //   By default Chromium enables the "PerMonitorV2" strategy for high DPI awareness. However SWT does not yet support
+    //   "PerMonitorV2", but only "System" DPI awareness. Mismatching DPI awareness between the render process (chromium)
+    //   and the host process (swt/java) causes strange visual artifacts.
+    //
+    //   Thus set "System" DPI awareness here, to override Chromiums default to match SWT.
+    unsafe {
+        winapi::um::winuser::SetProcessDpiAwarenessContext(
+            winapi::shared::windef::DPI_AWARENESS_CONTEXT_SYSTEM_AWARE,
+        );
+    }
+
     let main_args = chromium::utils::prepare_args();
     let mut app = app::App::new();
     let exit_code: c_int =


### PR DESCRIPTION
By default Chromium enables the "PerMonitorV2" strategy for high DPI awareness. SWT instead defaults to "System" awareness as it does not yet support per monitor scaling (https://github.com/eclipse-platform/eclipse.platform.swt/issues/131). 

This leads to a mismatch in DPI settings between the Chromium render process (chromium_subp) and the host process (SWT application). If the browser widget is created on one monitor and then moved to another monitor, SWT does not rescale, but the Chromium render process does. This results in Chromium delivering a "too large" screen texture to SWT, which in turn results in strange visual artrifacts in the SWT application.

This PR forces chromium_subp to also use System Aware DPI scaling. If SWT supports PerMonitor scaling in the future, we'll have to adapt. 