### PR TITLE
Disable cache usage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  rebase-strategy: disabled
+  rebase-strategy: auto
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
-  rebase-strategy: disabled
+  rebase-strategy: auto
 - package-ecosystem: cargo
   directory: "/native"
   schedule:
     interval: daily
-  rebase-strategy: disabled
+  rebase-strategy: auto

--- a/java/org.eclipse.set.browser.lib/src/org/eclipse/set/browser/lib/ChromiumLib.java
+++ b/java/org.eclipse.set.browser.lib/src/org/eclipse/set/browser/lib/ChromiumLib.java
@@ -255,7 +255,7 @@ public class ChromiumLib extends C {
 	 * @param logPath
 	 */
 	public static final native void cefswt_init(long app, String subprocessPath,
-			String cefPath, String tempPath, String userAgentProduct,
+			String cefPath, String userAgentProduct,
 			String locale, int debugPort, String logPath, int logLevel);
 
 	/**

--- a/java/org.eclipse.set.browser/src/org/eclipse/set/browser/cef/ChromiumStatic.java
+++ b/java/org.eclipse.set.browser/src/org/eclipse/set/browser/cef/ChromiumStatic.java
@@ -135,7 +135,7 @@ public class ChromiumStatic {
 
 			ChromiumLib.cefswt_init(app.get(),
 					CEFLibrary.getSubprocessExePath(),
-					CEFResource.getPath().toAbsolutePath().normalize().toString(), CEFLibrary.getTempPath(),
+					CEFResource.getPath().toAbsolutePath().normalize().toString(),
 					configuration.UserAgentProduct, configuration.Locale,
 					configuration.DebugPort, configuration.LogPath,
 					configuration.LogLevel.getValue());

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,21 +30,21 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.66",
+ "syn",
  "which",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cesu8"
@@ -86,7 +95,7 @@ version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -117,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -128,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.4"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
@@ -138,15 +147,34 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -179,9 +207,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -191,34 +219,37 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-targets",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minimal-lexical"
@@ -228,29 +259,35 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.15"
+name = "once_cell"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -266,24 +303,51 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "same-file"
@@ -302,20 +366,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -324,50 +377,50 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "lazy_static",
- "libc",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -388,11 +441,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -400,3 +453,76 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/native/chromium/Cargo.toml
+++ b/native/chromium/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [lib]
-crate_type = ["rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 chromium_jni_utils = { path = "../chromium_jni_utils/" }
@@ -23,3 +23,4 @@ missing_safety_doc = "allow"
 not_unsafe_ptr_arg_deref = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
+missing_transmute_annotations = "allow"

--- a/native/chromium/src/cef/mod.rs
+++ b/native/chromium/src/cef/mod.rs
@@ -490,7 +490,7 @@ pub enum cef_content_setting_types_t {
     CEF_CONTENT_SETTING_TYPE_PERMISSION_AUTOREVOCATION_DATA = 62,
     #[doc = " Stores per-origin state of the most recently selected directory for the\n use by the File System Access API."]
     CEF_CONTENT_SETTING_TYPE_FILE_SYSTEM_LAST_PICKED_DIRECTORY = 63,
-    #[doc = " Controls access to the getDisplayMedia API."]
+    #[doc = " Controls access to the getDisplayMedia API when {preferCurrentTab: true}\n is specified."]
     CEF_CONTENT_SETTING_TYPE_DISPLAY_CAPTURE = 64,
     #[doc = " Website setting to store permissions metadata granted to paths on the\n local file system via the File System Access API.\n |FILE_SYSTEM_WRITE_GUARD| is the corresponding \"guard\" setting. The stored\n data represents valid permission only if\n |FILE_SYSTEM_ACCESS_EXTENDED_PERMISSION| is enabled via user opt-in.\n Otherwise, they represent \"recently granted but revoked permission\", which\n are used to restore the permission."]
     CEF_CONTENT_SETTING_TYPE_FILE_SYSTEM_ACCESS_CHOOSER_DATA = 65,
@@ -502,8 +502,8 @@ pub enum cef_content_setting_types_t {
     CEF_CONTENT_SETTING_TYPE_HTTP_ALLOWED = 68,
     #[doc = " Stores metadata related to form fill, such as e.g. whether user data was\n autofilled on a specific website."]
     CEF_CONTENT_SETTING_TYPE_FORMFILL_METADATA = 69,
-    #[doc = " Setting to indicate that there is an active federated sign-in session\n between a specified relying party and a specified identity provider for\n a specified account. When this is present it allows access to session\n management capabilities between the sites. This setting is associated\n with the relying party's origin.\n Obsolete on Nov 2023."]
-    CEF_CONTENT_SETTING_TYPE_DEPRECATED_FEDERATED_IDENTITY_ACTIVE_SESSION = 70,
+    #[doc = " Setting to indicate that there is an active federated sign-in session\n between a specified relying party and a specified identity provider for\n a specified account. When this is present it allows access to session\n management capabilities between the sites. This setting is associated\n with the relying party's origin."]
+    CEF_CONTENT_SETTING_TYPE_FEDERATED_IDENTITY_ACTIVE_SESSION = 70,
     #[doc = " Setting to indicate whether Chrome should automatically apply darkening to\n web content."]
     CEF_CONTENT_SETTING_TYPE_AUTO_DARK_WEB_CONTENT = 71,
     #[doc = " Setting to indicate whether Chrome should request the desktop view of a\n site instead of the mobile one."]
@@ -540,30 +540,18 @@ pub enum cef_content_setting_types_t {
     CEF_CONTENT_SETTING_TYPE_ALL_SCREEN_CAPTURE = 87,
     #[doc = " Stores per origin metadata for cookie controls."]
     CEF_CONTENT_SETTING_TYPE_COOKIE_CONTROLS_METADATA = 88,
-    #[doc = " Content Setting for temporary 3PC accesses granted by user behavior\n heuristics."]
-    CEF_CONTENT_SETTING_TYPE_TPCD_HEURISTICS_GRANTS = 89,
-    #[doc = " Content Setting for 3PC accesses granted by metadata delivered via the\n component updater service. This type will only be used when\n `net::features::kTpcdMetadataGrants` is enabled."]
-    CEF_CONTENT_SETTING_TYPE_TPCD_METADATA_GRANTS = 90,
     #[doc = " Content Setting for 3PC accesses granted via 3PC deprecation trial."]
-    CEF_CONTENT_SETTING_TYPE_TPCD_TRIAL = 91,
-    #[doc = " Content Setting for 3PC accesses granted via top-level 3PC deprecation\n trial. Similar to TPCD_TRIAL, but applicable at the page-level for the\n lifetime of the page that served the token, rather than being specific to\n a requesting-origin/top-level-site combination and persistent."]
-    CEF_CONTENT_SETTING_TYPE_TOP_LEVEL_TPCD_TRIAL = 92,
+    CEF_CONTENT_SETTING_TYPE_TPCD_SUPPORT = 89,
     #[doc = " Content setting used to indicate whether entering picture-in-picture\n automatically should be enabled."]
-    CEF_CONTENT_SETTING_TYPE_AUTO_PICTURE_IN_PICTURE = 93,
+    CEF_CONTENT_SETTING_TYPE_AUTO_PICTURE_IN_PICTURE = 90,
+    #[doc = " Content Setting for 3PC accesses granted by metadata delivered via the\n component updater service. This type will only be used when\n `net::features::kTpcdMetadataGrants` is enabled."]
+    CEF_CONTENT_SETTING_TYPE_TPCD_METADATA_GRANTS = 91,
     #[doc = " Whether user has opted into keeping file/directory permissions persistent\n between visits for a given origin. When enabled, permission metadata\n stored under |FILE_SYSTEM_ACCESS_CHOOSER_DATA| can auto-grant incoming\n permission request."]
-    CEF_CONTENT_SETTING_TYPE_FILE_SYSTEM_ACCESS_EXTENDED_PERMISSION = 94,
-    #[doc = " Whether the FSA Persistent Permissions restore prompt is eligible to be\n shown to the user, for a given origin."]
-    CEF_CONTENT_SETTING_TYPE_FILE_SYSTEM_ACCESS_RESTORE_PERMISSION = 95,
-    #[doc = " Whether an application capturing another tab, may scroll and zoom\n the captured tab."]
-    CEF_CONTENT_SETTING_TYPE_CAPTURED_SURFACE_CONTROL = 96,
-    #[doc = " Content setting for access to smart card readers.\n The \"guard\" content setting stores whether to allow sites to access the\n Smart Card API."]
-    CEF_CONTENT_SETTING_TYPE_SMART_CARD_GUARD = 97,
-    #[doc = " Content setting for access to smart card readers.\n The \"guard\" content setting stores whether to allow sites to access the\n Smart Card API."]
-    CEF_CONTENT_SETTING_TYPE_SMART_CARD_DATA = 98,
-    #[doc = " Content settings for access to printers for the Web Printing API."]
-    CEF_CONTENT_SETTING_TYPE_WEB_PRINTING = 99,
-    #[doc = " Content settings for access to printers for the Web Printing API."]
-    CEF_CONTENT_SETTING_TYPE_NUM_TYPES = 100,
+    CEF_CONTENT_SETTING_TYPE_FILE_SYSTEM_ACCESS_EXTENDED_PERMISSION = 92,
+    #[doc = " Content Setting for temporary 3PC accesses granted by user behavior\n heuristics."]
+    CEF_CONTENT_SETTING_TYPE_TPCD_HEURISTICS_GRANTS = 93,
+    #[doc = " Content Setting for temporary 3PC accesses granted by user behavior\n heuristics."]
+    CEF_CONTENT_SETTING_TYPE_NUM_TYPES = 94,
 }
 #[repr(i32)]
 #[doc = "\n Supported content setting values. Should be kept in sync with Chromium's\n ContentSetting type.\n"]
@@ -681,7 +669,7 @@ pub struct _cef_settings_t {
     pub locales_dir_path: cef_string_t,
     #[doc = "\n Set to true (1) to disable loading of pack files for resources and\n locales. A resource bundle handler must be provided for the browser and\n render processes via CefApp::GetResourceBundleHandler() if loading of pack\n files is disabled. Also configurable using the \"disable-pack-loading\"\n command- line switch.\n"]
     pub pack_loading_disabled: ::std::os::raw::c_int,
-    #[doc = "\n Set to a value between 1024 and 65535 to enable remote debugging on the\n specified port. Also configurable using the \"remote-debugging-port\"\n command-line switch. Specifying 0 via the command-line switch will result\n in the selection of an ephemeral port and the port number will be printed\n as part of the WebSocket endpoint URL to stderr. If a cache directory path\n is provided the port will also be written to the\n <cache-dir>/DevToolsActivePort file. Remote debugging can be accessed by\n loading the chrome://inspect page in Google Chrome. Port numbers 9222 and\n 9229 are discoverable by default. Other port numbers may need to be\n configured via \"Discover network targets\" on the Devices tab.\n"]
+    #[doc = "\n Set to a value between 1024 and 65535 to enable remote debugging on the\n specified port. Also configurable using the \"remote-debugging-port\"\n command-line switch. Remote debugging can be accessed by loading the\n chrome://inspect page in Google Chrome. Port numbers 9222 and 9229 are\n discoverable by default. Other port numbers may need to be configured via\n \"Discover network targets\" on the Devices tab.\n"]
     pub remote_debugging_port: ::std::os::raw::c_int,
     #[doc = "\n The number of stack trace frames to capture for uncaught exceptions.\n Specify a positive value to enable the\n CefRenderProcessHandler::OnUncaughtException() callback. Specify 0\n (default value) and OnUncaughtException() will not be called. Also\n configurable using the \"uncaught-exception-stack-size\" command-line\n switch.\n"]
     pub uncaught_exception_stack_size: ::std::os::raw::c_int,
@@ -1023,7 +1011,6 @@ pub enum cef_errorcode_t {
     ERR_TOO_MANY_ACCEPT_CH_RESTARTS = -382,
     ERR_INCONSISTENT_IP_ADDRESS_SPACE = -383,
     ERR_CACHED_IP_ADDRESS_SPACE_BLOCKED_BY_PRIVATE_NETWORK_ACCESS_POLICY = -384,
-    ERR_BLOCKED_BY_PRIVATE_NETWORK_ACCESS_CHECKS = -385,
     ERR_CACHE_MISS = -400,
     ERR_CACHE_READ_FAILURE = -401,
     ERR_CACHE_WRITE_FAILURE = -402,
@@ -1885,8 +1872,6 @@ pub struct _cef_pdf_print_settings_t {
     pub footer_template: cef_string_t,
     #[doc = "\n Set to true (1) to generate tagged (accessible) PDF.\n"]
     pub generate_tagged_pdf: ::std::os::raw::c_int,
-    #[doc = "\n Set to true (1) to generate a document outline.\n"]
-    pub generate_document_outline: ::std::os::raw::c_int,
 }
 #[repr(i32)]
 #[doc = "\n Supported UI scale factors for the platform. SCALE_FACTOR_NONE is used for\n density independent resources such as string, html/js files or an image that\n can be used for any scale factors (such as wallpapers).\n"]
@@ -2181,7 +2166,7 @@ pub struct _cef_media_sink_device_info_t {
 }
 impl cef_chrome_page_action_icon_type_t {
     pub const CEF_CPAIT_MAX_VALUE: cef_chrome_page_action_icon_type_t =
-        cef_chrome_page_action_icon_type_t::CEF_CPAIT_PRICE_READ_ANYTHING;
+        cef_chrome_page_action_icon_type_t::CEF_CPAIT_PRICE_INSIGHTS;
 }
 #[repr(i32)]
 #[doc = "\n Chrome page action icon types. Should be kept in sync with Chromium's\n PageActionIconType type.\n"]
@@ -2214,7 +2199,6 @@ pub enum cef_chrome_page_action_icon_type_t {
     CEF_CPAIT_SAVE_IBAN = 24,
     CEF_CPAIT_MANDATORY_REAUTH = 25,
     CEF_CPAIT_PRICE_INSIGHTS = 26,
-    CEF_CPAIT_PRICE_READ_ANYTHING = 27,
 }
 impl cef_chrome_toolbar_button_type_t {
     pub const CEF_CTBT_MAX_VALUE: cef_chrome_toolbar_button_type_t =
@@ -4067,10 +4051,9 @@ pub struct _cef_frame_t {
     pub get_name: ::std::option::Option<
         unsafe extern "C" fn(self_: *mut _cef_frame_t) -> cef_string_userfree_t,
     >,
-    #[doc = "\n Returns the globally unique identifier for this frame or NULL if the\n underlying frame does not yet exist.\n\n The resulting string must be freed by calling cef_string_userfree_free()."]
-    pub get_identifier: ::std::option::Option<
-        unsafe extern "C" fn(self_: *mut _cef_frame_t) -> cef_string_userfree_t,
-    >,
+    #[doc = "\n Returns the globally unique identifier for this frame or < 0 if the\n underlying frame does not yet exist.\n"]
+    pub get_identifier:
+        ::std::option::Option<unsafe extern "C" fn(self_: *mut _cef_frame_t) -> i64>,
     #[doc = "\n Returns the parent of this frame or NULL if this is the main (top-level)\n frame.\n"]
     pub get_parent:
         ::std::option::Option<unsafe extern "C" fn(self_: *mut _cef_frame_t) -> *mut _cef_frame_t>,
@@ -4349,7 +4332,7 @@ pub struct _cef_cookie_manager_t {
 #[doc = "\n Structure used for managing cookies. The functions of this structure may be\n called on any thread unless otherwise indicated.\n"]
 pub type cef_cookie_manager_t = _cef_cookie_manager_t;
 extern "C" {
-    #[doc = "\n Returns the global cookie manager. By default data will be stored at\n cef_settings_t.cache_path if specified or in memory otherwise. If |callback|\n is non-NULL it will be executed asnychronously on the UI thread after the\n manager's storage has been initialized. Using this function is equivalent to\n calling cef_request_context_t::cef_request_context_get_global_context()-\n >GetDefaultCookieManager().\n"]
+    #[doc = "\n Returns the global cookie manager. By default data will be stored at\n cef_settings_t.cache_path if specified or in memory otherwise. If |callback|\n is non-NULL it will be executed asnychronously on the UI thread after the\n manager's storage has been initialized. Using this function is equivalent to\n calling cef_request_context_t::cef_request_context_get_global_context()->Get\n DefaultCookieManager().\n"]
     pub fn cef_cookie_manager_get_global_manager(
         callback: *mut _cef_completion_callback_t,
     ) -> *mut cef_cookie_manager_t;
@@ -4575,7 +4558,7 @@ pub struct _cef_media_router_t {
 #[doc = "\n Supports discovery of and communication with media devices on the local\n network via the Cast and DIAL protocols. The functions of this structure may\n be called on any browser process thread unless otherwise indicated.\n"]
 pub type cef_media_router_t = _cef_media_router_t;
 extern "C" {
-    #[doc = "\n Returns the MediaRouter object associated with the global request context.\n If |callback| is non-NULL it will be executed asnychronously on the UI\n thread after the manager's storage has been initialized. Equivalent to\n calling cef_request_context_t::cef_request_context_get_global_context()-\n >get_media_router().\n"]
+    #[doc = "\n Returns the MediaRouter object associated with the global request context.\n If |callback| is non-NULL it will be executed asnychronously on the UI\n thread after the manager's storage has been initialized. Equivalent to\n calling cef_request_context_t::cef_request_context_get_global_context()->get\n _media_router().\n"]
     pub fn cef_media_router_get_global(
         callback: *mut _cef_completion_callback_t,
     ) -> *mut cef_media_router_t;
@@ -4610,7 +4593,7 @@ pub struct _cef_media_observer_t {
             state: cef_media_route_connection_state_t,
         ),
     >,
-    #[doc = "\n A message was received over |route|. |message| is only valid for the scope\n of this callback and should be copied if necessary.\n"]
+    #[doc = "\n A message was recieved over |route|. |message| is only valid for the scope\n of this callback and should be copied if necessary.\n"]
     pub on_route_message_received: ::std::option::Option<
         unsafe extern "C" fn(
             self_: *mut _cef_media_observer_t,
@@ -4803,6 +4786,11 @@ pub type cef_preference_manager_t = _cef_preference_manager_t;
 extern "C" {
     #[doc = "\n Returns the global preference manager object.\n"]
     pub fn cef_preference_manager_get_global() -> *mut cef_preference_manager_t;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _cef_request_context_handler_t {
+    _unused: [u8; 0],
 }
 #[doc = "\n Callback structure for cef_request_context_t::ResolveHost.\n"]
 #[repr(C)]
@@ -5070,14 +5058,11 @@ pub struct _cef_browser_t {
         unsafe extern "C" fn(self_: *mut _cef_browser_t) -> *mut _cef_frame_t,
     >,
     #[doc = "\n Returns the frame with the specified identifier, or NULL if not found.\n"]
-    pub get_frame_by_identifier: ::std::option::Option<
-        unsafe extern "C" fn(
-            self_: *mut _cef_browser_t,
-            identifier: *const cef_string_t,
-        ) -> *mut _cef_frame_t,
+    pub get_frame_byident: ::std::option::Option<
+        unsafe extern "C" fn(self_: *mut _cef_browser_t, identifier: i64) -> *mut _cef_frame_t,
     >,
     #[doc = "\n Returns the frame with the specified name, or NULL if not found.\n"]
-    pub get_frame_by_name: ::std::option::Option<
+    pub get_frame: ::std::option::Option<
         unsafe extern "C" fn(
             self_: *mut _cef_browser_t,
             name: *const cef_string_t,
@@ -5088,7 +5073,11 @@ pub struct _cef_browser_t {
         ::std::option::Option<unsafe extern "C" fn(self_: *mut _cef_browser_t) -> usize>,
     #[doc = "\n Returns the identifiers of all existing frames.\n"]
     pub get_frame_identifiers: ::std::option::Option<
-        unsafe extern "C" fn(self_: *mut _cef_browser_t, identifiers: cef_string_list_t),
+        unsafe extern "C" fn(
+            self_: *mut _cef_browser_t,
+            identifiersCount: *mut usize,
+            identifiers: *mut i64,
+        ),
     >,
     #[doc = "\n Returns the names of all existing frames.\n"]
     pub get_frame_names: ::std::option::Option<
@@ -6189,7 +6178,7 @@ pub struct _cef_menu_model_t {
             color: *mut cef_color_t,
         ) -> ::std::os::raw::c_int,
     >,
-    #[doc = "\n Sets the font list for the specified |command_id|. If |font_list| is NULL\n the system font will be used. Returns true (1) on success. The format is\n \"<FONT_FAMILY_LIST>,[STYLES] <SIZE>\", where:\n - FONT_FAMILY_LIST is a comma-separated list of font family names,\n - STYLES is an optional space-separated list of style names (case-\n   sensitive \"Bold\" and \"Italic\" are supported), and\n - SIZE is an integer font size in pixels with the suffix \"px\".\n\n Here are examples of valid font description strings:\n - \"Arial, Helvetica, Bold Italic 14px\"\n - \"Arial, 14px\"\n"]
+    #[doc = "\n Sets the font list for the specified |command_id|. If |font_list| is NULL\n the system font will be used. Returns true (1) on success. The format is\n \"<FONT_FAMILY_LIST>,[STYLES] <SIZE>\", where: - FONT_FAMILY_LIST is a\n comma-separated list of font family names, - STYLES is an optional space-\n separated list of style names\n   (case-sensitive \"Bold\" and \"Italic\" are supported), and\n - SIZE is an integer font size in pixels with the suffix \"px\".\n\n Here are examples of valid font description strings: - \"Arial, Helvetica,\n Bold Italic 14px\" - \"Arial, 14px\"\n"]
     pub set_font_list: ::std::option::Option<
         unsafe extern "C" fn(
             self_: *mut _cef_menu_model_t,
@@ -6197,7 +6186,7 @@ pub struct _cef_menu_model_t {
             font_list: *const cef_string_t,
         ) -> ::std::os::raw::c_int,
     >,
-    #[doc = "\n Sets the font list for the specified |index|. Specify an |index| value of\n - 1 to set the default font. If |font_list| is NULL the system font will\n - FONT_FAMILY_LIST is a comma-separated list of font family names,\n - STYLES is an optional space-separated list of style names (case-\n   sensitive \"Bold\" and \"Italic\" are supported), and\n - SIZE is an integer font size in pixels with the suffix \"px\".\n\n Here are examples of valid font description strings:\n - \"Arial, Helvetica, Bold Italic 14px\"\n - \"Arial, 14px\"\n"]
+    #[doc = "\n Sets the font list for the specified |index|. Specify an |index| value of\n -1 to set the default font. If |font_list| is NULL the system font will be\n used. Returns true (1) on success. The format is\n \"<FONT_FAMILY_LIST>,[STYLES] <SIZE>\", where: - FONT_FAMILY_LIST is a\n comma-separated list of font family names, - STYLES is an optional space-\n separated list of style names\n   (case-sensitive \"Bold\" and \"Italic\" are supported), and\n - SIZE is an integer font size in pixels with the suffix \"px\".\n\n Here are examples of valid font description strings: - \"Arial, Helvetica,\n Bold Italic 14px\" - \"Arial, 14px\"\n"]
     pub set_font_list_at: ::std::option::Option<
         unsafe extern "C" fn(
             self_: *mut _cef_menu_model_t,
@@ -6872,7 +6861,7 @@ pub struct _cef_focus_handler_t {
         unsafe extern "C" fn(self_: *mut _cef_focus_handler_t, browser: *mut _cef_browser_t),
     >,
 }
-#[doc = "\n Implement this structure to handle events related to cef_frame_t life span.\n The order of callbacks is:\n\n (1) During initial cef_browser_host_t creation and navigation of the main\n frame:\n - cef_frame_handler_t::OnFrameCreated => The initial main frame object has\n   been created. Any commands will be queued until the frame is attached.\n - cef_frame_handler_t::OnMainFrameChanged => The initial main frame object\n   has been assigned to the browser.\n - cef_life_span_handler_t::OnAfterCreated => The browser is now valid and\n   can be used.\n - cef_frame_handler_t::OnFrameAttached => The initial main frame object is\n   now connected to its peer in the renderer process. Commands can be routed.\n\n (2) During further cef_browser_host_t navigation/loading of the main frame\n     and/or sub-frames:\n - cef_frame_handler_t::OnFrameCreated => A new main frame or sub-frame\n   object has been created. Any commands will be queued until the frame is\n   attached.\n - cef_frame_handler_t::OnFrameAttached => A new main frame or sub-frame\n   object is now connected to its peer in the renderer process. Commands can\n   be routed.\n - cef_frame_handler_t::OnFrameDetached => An existing main frame or sub-\n   frame object has lost its connection to the renderer process. If multiple\n   objects are detached at the same time then notifications will be sent for\n   any sub-frame objects before the main frame object. Commands can no longer\n   be routed and will be discarded.\n - cef_frame_handler_t::OnMainFrameChanged => A new main frame object has\n   been assigned to the browser. This will only occur with cross-origin\n   navigation or re-navigation after renderer process termination (due to\n   crashes, etc).\n\n (3) During final cef_browser_host_t destruction of the main frame:\n - cef_frame_handler_t::OnFrameDetached => Any sub-frame objects have lost\n   their connection to the renderer process. Commands can no longer be routed\n   and will be discarded.\n - cef_life_span_handler_t::OnBeforeClose => The browser has been destroyed.\n - cef_frame_handler_t::OnFrameDetached => The main frame object have lost\n   its connection to the renderer process. Notifications will be sent for any\n   sub-frame objects before the main frame object. Commands can no longer be\n   routed and will be discarded.\n - cef_frame_handler_t::OnMainFrameChanged => The final main frame object has\n   been removed from the browser.\n\n Cross-origin navigation and/or loading receives special handling.\n\n When the main frame navigates to a different origin the OnMainFrameChanged\n callback (2) will be executed with the old and new main frame objects.\n\n When a new sub-frame is loaded in, or an existing sub-frame is navigated to,\n a different origin from the parent frame, a temporary sub-frame object will\n first be created in the parent's renderer process. That temporary sub-frame\n will then be discarded after the real cross-origin sub-frame is created in\n the new/target renderer process. The client will receive cross-origin\n navigation callbacks (2) for the transition from the temporary sub-frame to\n the real sub-frame. The temporary sub-frame will not receive or execute\n commands during this transitional period (any sent commands will be\n discarded).\n\n When a new popup browser is created in a different origin from the parent\n browser, a temporary main frame object for the popup will first be created\n in the parent's renderer process. That temporary main frame will then be\n discarded after the real cross-origin main frame is created in the\n new/target renderer process. The client will receive creation and initial\n navigation callbacks (1) for the temporary main frame, followed by cross-\n origin navigation callbacks (2) for the transition from the temporary main\n frame to the real main frame. The temporary main frame may receive and\n execute commands during this transitional period (any sent commands may be\n executed, but the behavior is potentially undesirable since they execute in\n the parent browser's renderer process and not the new/target renderer\n process).\n\n Callbacks will not be executed for placeholders that may be created during\n pre-commit navigation for sub-frames that do not yet exist in the renderer\n process. Placeholders will have cef_frame_t::get_identifier() == -4.\n\n The functions of this structure will be called on the UI thread unless\n otherwise indicated.\n"]
+#[doc = "\n Implement this structure to handle events related to cef_frame_t life span.\n The order of callbacks is:\n\n (1) During initial cef_browser_host_t creation and navigation of the main\n frame: - cef_frame_handler_t::OnFrameCreated => The initial main frame\n object has been\n   created. Any commands will be queued until the frame is attached.\n - cef_frame_handler_t::OnMainFrameChanged => The initial main frame object\n has\n   been assigned to the browser.\n - cef_life_span_handler_t::OnAfterCreated => The browser is now valid and\n can be\n   used.\n - cef_frame_handler_t::OnFrameAttached => The initial main frame object is\n now\n   connected to its peer in the renderer process. Commands can be routed.\n\n (2) During further cef_browser_host_t navigation/loading of the main frame\n     and/or sub-frames:\n - cef_frame_handler_t::OnFrameCreated => A new main frame or sub-frame\n object\n   has been created. Any commands will be queued until the frame is attached.\n - cef_frame_handler_t::OnFrameAttached => A new main frame or sub-frame\n object\n   is now connected to its peer in the renderer process. Commands can be\n   routed.\n - cef_frame_handler_t::OnFrameDetached => An existing main frame or sub-\n frame\n   object has lost its connection to the renderer process. If multiple\n   objects are detached at the same time then notifications will be sent for\n   any sub-frame objects before the main frame object. Commands can no longer\n   be routed and will be discarded.\n - cef_frame_handler_t::OnMainFrameChanged => A new main frame object has\n been\n   assigned to the browser. This will only occur with cross-origin navigation\n   or re-navigation after renderer process termination (due to crashes, etc).\n\n (3) During final cef_browser_host_t destruction of the main frame: -\n cef_frame_handler_t::OnFrameDetached => Any sub-frame objects have lost\n their\n   connection to the renderer process. Commands can no longer be routed and\n   will be discarded.\n - cef_life_span_handler_t::OnBeforeClose => The browser has been destroyed.\n - cef_frame_handler_t::OnFrameDetached => The main frame object have lost\n its\n   connection to the renderer process. Notifications will be sent for any\n   sub-frame objects before the main frame object. Commands can no longer be\n   routed and will be discarded.\n - cef_frame_handler_t::OnMainFrameChanged => The final main frame object has\n   been removed from the browser.\n\n Cross-origin navigation and/or loading receives special handling.\n\n When the main frame navigates to a different origin the OnMainFrameChanged\n callback (2) will be executed with the old and new main frame objects.\n\n When a new sub-frame is loaded in, or an existing sub-frame is navigated to,\n a different origin from the parent frame, a temporary sub-frame object will\n first be created in the parent's renderer process. That temporary sub-frame\n will then be discarded after the real cross-origin sub-frame is created in\n the new/target renderer process. The client will receive cross-origin\n navigation callbacks (2) for the transition from the temporary sub-frame to\n the real sub-frame. The temporary sub-frame will not recieve or execute\n commands during this transitional period (any sent commands will be\n discarded).\n\n When a new popup browser is created in a different origin from the parent\n browser, a temporary main frame object for the popup will first be created\n in the parent's renderer process. That temporary main frame will then be\n discarded after the real cross-origin main frame is created in the\n new/target renderer process. The client will recieve creation and initial\n navigation callbacks (1) for the temporary main frame, followed by cross-\n origin navigation callbacks (2) for the transition from the temporary main\n frame to the real main frame. The temporary main frame may receive and\n execute commands during this transitional period (any sent commands may be\n executed, but the behavior is potentially undesirable since they execute in\n the parent browser's renderer process and not the new/target renderer\n process).\n\n Callbacks will not be executed for placeholders that may be created during\n pre-commit navigation for sub-frames that do not yet exist in the renderer\n process. Placeholders will have cef_frame_t::get_identifier() == -4.\n\n The functions of this structure will be called on the UI thread unless\n otherwise indicated.\n"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _cef_frame_handler_t {
@@ -7032,7 +7021,7 @@ pub struct _cef_life_span_handler_t {
     pub on_after_created: ::std::option::Option<
         unsafe extern "C" fn(self_: *mut _cef_life_span_handler_t, browser: *mut _cef_browser_t),
     >,
-    #[doc = "\n Called when a browser has received a request to close. This may result\n directly from a call to cef_browser_host_t::*close_browser() or indirectly\n if the browser is parented to a top-level window created by CEF and the\n user attempts to close that window (by clicking the 'X', for example). The\n do_close() function will be called after the JavaScript 'onunload' event\n has been fired.\n\n An application should handle top-level owner window close notifications by\n calling cef_browser_host_t::try_close_browser() or\n cef_browser_host_t::CloseBrowser(false (0)) instead of allowing the window\n to close immediately (see the examples below). This gives CEF an\n opportunity to process the 'onbeforeunload' event and optionally cancel\n the close before do_close() is called.\n\n When windowed rendering is enabled CEF will internally create a window or\n view to host the browser. In that case returning false (0) from do_close()\n will send the standard close notification to the browser's top-level owner\n window (e.g. WM_CLOSE on Windows, performClose: on OS X, \"delete_event\" on\n Linux or cef_window_delegate_t::can_close() callback from Views). If the\n browser's host window/view has already been destroyed (via view hierarchy\n tear-down, for example) then do_close() will not be called for that\n browser since is no longer possible to cancel the close.\n\n When windowed rendering is disabled returning false (0) from do_close()\n will cause the browser object to be destroyed immediately.\n\n If the browser's top-level owner window requires a non-standard close\n notification then send that notification from do_close() and return true\n (1).\n\n The cef_life_span_handler_t::on_before_close() function will be called\n after do_close() (if do_close() is called) and immediately before the\n browser object is destroyed. The application should only exit after\n on_before_close() has been called for all existing browsers.\n\n The below examples describe what should happen during window close when\n the browser is parented to an application-provided top-level window.\n\n Example 1: Using cef_browser_host_t::try_close_browser(). This is\n recommended for clients using standard close handling and windows created\n on the browser process UI thread. 1.  User clicks the window close button\n which sends a close notification\n     to the application's top-level window.\n 2.  Application's top-level window receives the close notification and\n     calls TryCloseBrowser() (which internally calls CloseBrowser(false)).\n     TryCloseBrowser() returns false so the client cancels the window\n     close.\n 3.  JavaScript 'onbeforeunload' handler executes and shows the close\n     confirmation dialog (which can be overridden via\n     CefJSDialogHandler::OnBeforeUnloadDialog()).\n 4.  User approves the close. 5.  JavaScript 'onunload' handler executes.\n 6.  CEF sends a close notification to the application's top-level window\n     (because DoClose() returned false by default).\n 7.  Application's top-level window receives the close notification and\n     calls TryCloseBrowser(). TryCloseBrowser() returns true so the client\n     allows the window close.\n 8.  Application's top-level window is destroyed. 9.  Application's\n on_before_close() handler is called and the browser object\n     is destroyed.\n 10. Application exits by calling cef_quit_message_loop() if no other\n browsers\n     exist.\n\n Example 2: Using cef_browser_host_t::CloseBrowser(false (0)) and\n implementing the do_close() callback. This is recommended for clients\n using non-standard close handling or windows that were not created on the\n browser process UI thread. 1.  User clicks the window close button which\n sends a close notification\n     to the application's top-level window.\n 2.  Application's top-level window receives the close notification and:\n     A. Calls CefBrowserHost::CloseBrowser(false).\n     B. Cancels the window close.\n 3.  JavaScript 'onbeforeunload' handler executes and shows the close\n     confirmation dialog (which can be overridden via\n     CefJSDialogHandler::OnBeforeUnloadDialog()).\n 4.  User approves the close. 5.  JavaScript 'onunload' handler executes.\n 6.  Application's do_close() handler is called. Application will:\n     A. Set a flag to indicate that the next close attempt will be allowed.\n     B. Return false.\n 7.  CEF sends an close notification to the application's top-level window.\n 8.  Application's top-level window receives the close notification and\n     allows the window to close based on the flag from #6B.\n 9.  Application's top-level window is destroyed. 10. Application's\n on_before_close() handler is called and the browser object\n     is destroyed.\n 11. Application exits by calling cef_quit_message_loop() if no other\n browsers\n     exist.\n"]
+    #[doc = "\n Called when a browser has recieved a request to close. This may result\n directly from a call to cef_browser_host_t::*close_browser() or indirectly\n if the browser is parented to a top-level window created by CEF and the\n user attempts to close that window (by clicking the 'X', for example). The\n do_close() function will be called after the JavaScript 'onunload' event\n has been fired.\n\n An application should handle top-level owner window close notifications by\n calling cef_browser_host_t::try_close_browser() or\n cef_browser_host_t::CloseBrowser(false (0)) instead of allowing the window\n to close immediately (see the examples below). This gives CEF an\n opportunity to process the 'onbeforeunload' event and optionally cancel\n the close before do_close() is called.\n\n When windowed rendering is enabled CEF will internally create a window or\n view to host the browser. In that case returning false (0) from do_close()\n will send the standard close notification to the browser's top-level owner\n window (e.g. WM_CLOSE on Windows, performClose: on OS X, \"delete_event\" on\n Linux or cef_window_delegate_t::can_close() callback from Views). If the\n browser's host window/view has already been destroyed (via view hierarchy\n tear-down, for example) then do_close() will not be called for that\n browser since is no longer possible to cancel the close.\n\n When windowed rendering is disabled returning false (0) from do_close()\n will cause the browser object to be destroyed immediately.\n\n If the browser's top-level owner window requires a non-standard close\n notification then send that notification from do_close() and return true\n (1).\n\n The cef_life_span_handler_t::on_before_close() function will be called\n after do_close() (if do_close() is called) and immediately before the\n browser object is destroyed. The application should only exit after\n on_before_close() has been called for all existing browsers.\n\n The below examples describe what should happen during window close when\n the browser is parented to an application-provided top-level window.\n\n Example 1: Using cef_browser_host_t::try_close_browser(). This is\n recommended for clients using standard close handling and windows created\n on the browser process UI thread. 1.  User clicks the window close button\n which sends a close notification\n     to the application's top-level window.\n 2.  Application's top-level window receives the close notification and\n     calls TryCloseBrowser() (which internally calls CloseBrowser(false)).\n     TryCloseBrowser() returns false so the client cancels the window\n     close.\n 3.  JavaScript 'onbeforeunload' handler executes and shows the close\n     confirmation dialog (which can be overridden via\n     CefJSDialogHandler::OnBeforeUnloadDialog()).\n 4.  User approves the close. 5.  JavaScript 'onunload' handler executes.\n 6.  CEF sends a close notification to the application's top-level window\n     (because DoClose() returned false by default).\n 7.  Application's top-level window receives the close notification and\n     calls TryCloseBrowser(). TryCloseBrowser() returns true so the client\n     allows the window close.\n 8.  Application's top-level window is destroyed. 9.  Application's\n on_before_close() handler is called and the browser object\n     is destroyed.\n 10. Application exits by calling cef_quit_message_loop() if no other\n browsers\n     exist.\n\n Example 2: Using cef_browser_host_t::CloseBrowser(false (0)) and\n implementing the do_close() callback. This is recommended for clients\n using non-standard close handling or windows that were not created on the\n browser process UI thread. 1.  User clicks the window close button which\n sends a close notification\n     to the application's top-level window.\n 2.  Application's top-level window receives the close notification and:\n     A. Calls CefBrowserHost::CloseBrowser(false).\n     B. Cancels the window close.\n 3.  JavaScript 'onbeforeunload' handler executes and shows the close\n     confirmation dialog (which can be overridden via\n     CefJSDialogHandler::OnBeforeUnloadDialog()).\n 4.  User approves the close. 5.  JavaScript 'onunload' handler executes.\n 6.  Application's do_close() handler is called. Application will:\n     A. Set a flag to indicate that the next close attempt will be allowed.\n     B. Return false.\n 7.  CEF sends an close notification to the application's top-level window.\n 8.  Application's top-level window receives the close notification and\n     allows the window to close based on the flag from #6B.\n 9.  Application's top-level window is destroyed. 10. Application's\n on_before_close() handler is called and the browser object\n     is destroyed.\n 11. Application exits by calling cef_quit_message_loop() if no other\n browsers\n     exist.\n"]
     pub do_close: ::std::option::Option<
         unsafe extern "C" fn(
             self_: *mut _cef_life_span_handler_t,
@@ -7991,33 +7980,6 @@ extern "C" {
     #[doc = "\n Returns the singleton global cef_command_line_t object. The returned object\n will be read-only.\n"]
     pub fn cef_command_line_get_global() -> *mut cef_command_line_t;
 }
-#[doc = "\n Implement this structure to provide handler implementations. The handler\n instance will not be released until all objects related to the context have\n been destroyed.\n"]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _cef_request_context_handler_t {
-    #[doc = "\n Base structure.\n"]
-    pub base: cef_base_ref_counted_t,
-    #[doc = "\n Called on the browser process UI thread immediately after the request\n context has been initialized.\n"]
-    pub on_request_context_initialized: ::std::option::Option<
-        unsafe extern "C" fn(
-            self_: *mut _cef_request_context_handler_t,
-            request_context: *mut _cef_request_context_t,
-        ),
-    >,
-    #[doc = "\n Called on the browser process IO thread before a resource request is\n initiated. The |browser| and |frame| values represent the source of the\n request, and may be NULL for requests originating from service workers or\n cef_urlrequest_t. |request| represents the request contents and cannot be\n modified in this callback. |is_navigation| will be true (1) if the\n resource request is a navigation. |is_download| will be true (1) if the\n resource request is a download. |request_initiator| is the origin (scheme\n + domain) of the page that initiated the request. Set\n |disable_default_handling| to true (1) to disable default handling of the\n request, in which case it will need to be handled via\n cef_resource_request_handler_t::GetResourceHandler or it will be canceled.\n To allow the resource load to proceed with default handling return NULL.\n To specify a handler for the resource return a\n cef_resource_request_handler_t object. This function will not be called if\n the client associated with |browser| returns a non-NULL value from\n cef_request_handler_t::GetResourceRequestHandler for the same request\n (identified by cef_request_t::GetIdentifier).\n"]
-    pub get_resource_request_handler: ::std::option::Option<
-        unsafe extern "C" fn(
-            self_: *mut _cef_request_context_handler_t,
-            browser: *mut _cef_browser_t,
-            frame: *mut _cef_frame_t,
-            request: *mut _cef_request_t,
-            is_navigation: ::std::os::raw::c_int,
-            is_download: ::std::os::raw::c_int,
-            request_initiator: *const cef_string_t,
-            disable_default_handling: *mut ::std::os::raw::c_int,
-        ) -> *mut _cef_resource_request_handler_t,
-    >,
-}
 #[doc = "\n Structure used to implement browser process callbacks. The functions of this\n structure will be called on the browser process main thread unless otherwise\n indicated.\n"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone, JNICEFCallback)]
@@ -8054,15 +8016,9 @@ pub struct _cef_browser_process_handler_t {
     pub on_schedule_message_pump_work: ::std::option::Option<
         unsafe extern "C" fn(self_: *mut _cef_browser_process_handler_t, delay_ms: i64),
     >,
-    #[doc = "\n Return the default client for use with a newly created browser window\n (cef_browser_t object). If null is returned the cef_browser_t will be\n unmanaged (no callbacks will be executed for that cef_browser_t) and\n application shutdown will be blocked until the browser window is closed\n manually. This function is currently only used with the Chrome runtime\n when creating new browser windows via Chrome UI.\n"]
+    #[doc = "\n Return the default client for use with a newly created browser window. If\n null is returned the browser will be unmanaged (no callbacks will be\n executed for that browser) and application shutdown will be blocked until\n the browser window is closed manually. This function is currently only\n used with the chrome runtime.\n"]
     pub get_default_client: ::std::option::Option<
         unsafe extern "C" fn(self_: *mut _cef_browser_process_handler_t) -> *mut _cef_client_t,
-    >,
-    #[doc = "\n Return the default handler for use with a new user or incognito profile\n (cef_request_context_t object). If null is returned the\n cef_request_context_t will be unmanaged (no callbacks will be executed for\n that cef_request_context_t). This function is currently only used with the\n Chrome runtime when creating new browser windows via Chrome UI.\n"]
-    pub get_default_request_context_handler: ::std::option::Option<
-        unsafe extern "C" fn(
-            self_: *mut _cef_browser_process_handler_t,
-        ) -> *mut _cef_request_context_handler_t,
     >,
 }
 #[doc = "\n Implement this structure for asynchronous task execution. If the task is\n posted successfully and if the associated message loop is still running then\n the execute() function will be called on the target thread. If the task\n fails to post then the task object may be destroyed on the source thread\n instead of the target thread. For this reason be cautious when performing\n work in the task object destructor.\n"]
@@ -8927,7 +8883,7 @@ pub struct _cef_scheme_handler_factory_t {
 #[doc = "\n Structure that creates cef_resource_handler_t instances for handling scheme\n requests. The functions of this structure will always be called on the IO\n thread.\n"]
 pub type cef_scheme_handler_factory_t = _cef_scheme_handler_factory_t;
 extern "C" {
-    #[doc = "\n Register a scheme handler factory with the global request context. An NULL\n |domain_name| value for a standard scheme will cause the factory to match\n all domain names. The |domain_name| value will be ignored for non-standard\n schemes. If |scheme_name| is a built-in scheme and no handler is returned by\n |factory| then the built-in scheme handler factory will be called. If\n |scheme_name| is a custom scheme then you must also implement the\n cef_app_t::on_register_custom_schemes() function in all processes. This\n function may be called multiple times to change or remove the factory that\n matches the specified |scheme_name| and optional |domain_name|. Returns\n false (0) if an error occurs. This function may be called on any thread in\n the browser process. Using this function is equivalent to calling cef_reques\n t_context_t::cef_request_context_get_global_context()-\n >register_scheme_handler_factory().\n"]
+    #[doc = "\n Register a scheme handler factory with the global request context. An NULL\n |domain_name| value for a standard scheme will cause the factory to match\n all domain names. The |domain_name| value will be ignored for non-standard\n schemes. If |scheme_name| is a built-in scheme and no handler is returned by\n |factory| then the built-in scheme handler factory will be called. If\n |scheme_name| is a custom scheme then you must also implement the\n cef_app_t::on_register_custom_schemes() function in all processes. This\n function may be called multiple times to change or remove the factory that\n matches the specified |scheme_name| and optional |domain_name|. Returns\n false (0) if an error occurs. This function may be called on any thread in\n the browser process. Using this function is equivalent to calling cef_reques\n t_context_t::cef_request_context_get_global_context()->register_scheme_handl\n er_factory().\n"]
     pub fn cef_register_scheme_handler_factory(
         scheme_name: *const cef_string_t,
         domain_name: *const cef_string_t,
@@ -8935,7 +8891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = "\n Clear all scheme handler factories registered with the global request\n context. Returns false (0) on error. This function may be called on any\n thread in the browser process. Using this function is equivalent to calling\n cef_request_context_t::cef_request_context_get_global_context()-\n >clear_scheme_handler_factories().\n"]
+    #[doc = "\n Clear all scheme handler factories registered with the global request\n context. Returns false (0) on error. This function may be called on any\n thread in the browser process. Using this function is equivalent to calling\n cef_request_context_t::cef_request_context_get_global_context()->clear_schem\n e_handler_factories().\n"]
     pub fn cef_clear_scheme_handler_factories() -> ::std::os::raw::c_int;
 }
 #[doc = "\n Implement this structure to provide handler implementations. Methods will be\n called by the process and/or thread indicated.\n"]

--- a/native/chromium_jni/Cargo.toml
+++ b/native/chromium_jni/Cargo.toml
@@ -11,7 +11,7 @@ chromium_jni_macro = { path = "../chromium_jni_macro/" }
 chromium_jni_utils = { path = "../chromium_jni_utils/" }
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]
 
 [lints.clippy]
 missing_safety_doc = "allow"

--- a/native/chromium_jni_macro/src/derive_from_java_impl.rs
+++ b/native/chromium_jni_macro/src/derive_from_java_impl.rs
@@ -11,8 +11,8 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    parse_macro_input, punctuated::Punctuated, token::Comma, Data, DataStruct, DeriveInput,
-    Field, Fields,
+    parse_macro_input, punctuated::Punctuated, token::Comma, Data, DataStruct, DeriveInput, Field,
+    Fields,
 };
 
 /// Implementation for derive(FromJava)
@@ -52,7 +52,7 @@ pub fn derive_from_java_impl(tokens: TokenStream) -> TokenStream {
 fn build_initialization(
     fields: &Punctuated<Field, Comma>,
 ) -> impl Iterator<Item = proc_macro2::TokenStream> + '_ {
-    let fields = fields.iter().enumerate().map(move |(_i, field)| {
+    let fields = fields.iter().map(move |field| {
         let field_ident = field.ident.as_ref().unwrap();
         quote! { #field_ident: FromJavaMember::from_java_member(env, object, stringify!(#field_ident)) }
     });

--- a/native/chromium_jni_utils/Cargo.toml
+++ b/native/chromium_jni_utils/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2021"
 jni = "0.19.0"
 
 [lib]
-crate_type = ["rlib"]
+crate-type = ["rlib"]
+
+[lints.clippy]
+missing_transmute_annotations = "allow"

--- a/native/chromium_swt/Cargo.toml
+++ b/native/chromium_swt/Cargo.toml
@@ -20,3 +20,4 @@ winapi = { version = "0.3.9", features = ["winuser"] }
 missing_safety_doc = "allow"
 not_unsafe_ptr_arg_deref = "allow"
 too_many_arguments = "allow"
+missing_transmute_annotations = "allow"

--- a/native/chromium_swt/src/lib.rs
+++ b/native/chromium_swt/src/lib.rs
@@ -32,7 +32,6 @@ pub fn cefswt_init(
     japp: *mut cef::cef_app_t,
     subp_path: *const c_char,
     cef_path: *const c_char,
-    temp_path: *const c_char,
     user_agent_product: *const c_char,
     locale: *const c_char,
     debug_port: c_int,
@@ -41,7 +40,6 @@ pub fn cefswt_init(
 ) {
     let subp_path = chromium::utils::str_from_c(subp_path);
     let cef_path = chromium::utils::str_from_c(cef_path);
-    let temp_path = chromium::utils::str_from_c(temp_path);
     let log_path = chromium::utils::str_from_c(log_path);
     let log_level = unsafe { std::mem::transmute(log_level) };
 
@@ -49,7 +47,6 @@ pub fn cefswt_init(
 
     let subp = std::path::Path::new(&subp_path);
     let cef_dir = std::path::Path::new(&cef_path);
-    let temp_dir = std::path::Path::new(&temp_path);
 
     let subp_cef = chromium::utils::cef_string(subp.to_str().unwrap());
 
@@ -60,7 +57,6 @@ pub fn cefswt_init(
     let resources_cef = chromium::utils::cef_string(cef_dir.to_str().unwrap());
     let locales_cef = chromium::utils::cef_string(cef_dir.join("locales").to_str().unwrap());
     let framework_dir_cef = chromium::utils::cef_string_empty();
-    let cache_dir_cef = chromium::utils::cef_string(temp_dir.join("cef_cache").to_str().unwrap());
     let log_path = chromium::utils::cef_string(log_path);
 
     let settings = cef::_cef_settings_t {
@@ -72,8 +68,8 @@ pub fn cefswt_init(
         external_message_pump: 1,
         windowless_rendering_enabled: 0,
         command_line_args_disabled: 0,
-        cache_path: cache_dir_cef,
-        root_cache_path: cache_dir_cef,
+        cache_path: chromium::utils::cef_string_empty(),
+        root_cache_path: chromium::utils::cef_string_empty(),
         persist_session_cookies: 1,
         persist_user_preferences: 1,
         user_agent: chromium::utils::cef_string_empty(),


### PR DESCRIPTION
If no temp path is given, CEF behaves as if a private window is opened. As local storage is not used, we do not need the temp path.