### PR TITLE
Run message loop more often

### DIFF
--- a/java/org.eclipse.set.browser/src/org/eclipse/set/browser/cef/MessageLoop.java
+++ b/java/org.eclipse.set.browser/src/org/eclipse/set/browser/cef/MessageLoop.java
@@ -22,7 +22,7 @@ import org.eclipse.swt.widgets.Display;
  * @author Stuecker
  */
 public class MessageLoop {
-	private static final int LOOP = 75;
+	private static final int LOOP = 5;
 
 	private boolean loopDisable;
 
@@ -119,7 +119,7 @@ public class MessageLoop {
 		loopWork = () -> {
 			if (!loopShutdown && !Display.getDefault().isDisposed()) {
 				loop_work();
-				Display.getDefault().timerExec(LOOP * 2, loopWork);
+				Display.getDefault().timerExec(LOOP, loopWork);
 			}
 		};
 		Display.getDefault().timerExec(LOOP, loopWork);


### PR DESCRIPTION
Previously we were only running the CEF message loop once every 150ms. That causes massive slowdowns for some events (e.g. paste). 5ms seems to introduce no noticeable extra CPU load, but significantly improves performance.